### PR TITLE
Use `std::error::Error` (not `std::io::Error`)

### DIFF
--- a/haskell-ffi/src/bincode.rs
+++ b/haskell-ffi/src/bincode.rs
@@ -1,36 +1,37 @@
 use std::{
-    io::{Error, ErrorKind, Write},
+    io::{ErrorKind, Write},
     marker::PhantomData,
 };
+
+use crate::error::Result;
 
 /// Implement `to_haskell` using `bincode`
 ///
 /// The result will be length-prefixed ("bincode-in-Borsh").
-pub fn bincode_to_haskell<Tag, T, W>(
-    t: &T,
-    writer: &mut W,
-    _: PhantomData<Tag>,
-) -> Result<(), Error>
+pub fn bincode_to_haskell<Tag, T, W>(t: &T, writer: &mut W, _: PhantomData<Tag>) -> Result<()>
 where
     T: serde::ser::Serialize,
     W: Write,
 {
     match bincode::serialize(t) {
-        Ok(vec) => borsh::BorshSerialize::serialize(&vec, writer),
-        Err(e) => Err(Error::new(ErrorKind::InvalidData, e)),
+        Ok(vec) => {
+            borsh::BorshSerialize::serialize(&vec, writer)?;
+            Ok(())
+        }
+        Err(e) => Err(Box::new(std::io::Error::new(ErrorKind::InvalidData, e))),
     }
 }
 
 /// Implement `from_haskell` using `bincode`
 ///
 /// See als `bincode_to_haskell`
-pub fn bincode_from_haskell<Tag, T>(buf: &mut &[u8], _: PhantomData<Tag>) -> Result<T, Error>
+pub fn bincode_from_haskell<Tag, T>(buf: &mut &[u8], _: PhantomData<Tag>) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
     let vec: Vec<u8> = borsh::BorshDeserialize::deserialize(buf)?;
     match bincode::deserialize(vec.as_ref()) {
         Ok(x) => Ok(x),
-        Err(e) => Err(Error::new(ErrorKind::InvalidData, e)),
+        Err(e) => Err(Box::new(std::io::Error::new(ErrorKind::InvalidData, e))),
     }
 }

--- a/haskell-ffi/src/deriving_via.rs
+++ b/haskell-ffi/src/deriving_via.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     fmt::Debug,
     hash::{Hash, Hasher},
-    io::{Error, Write},
+    io::Write,
     marker::PhantomData,
 };
 
@@ -100,14 +100,20 @@ impl<Tag, T: Copy> Copy for Haskell<Tag, T> {}
 *******************************************************************************/
 
 impl<Tag, T: ToHaskell<Tag>> BorshSerialize for Haskell<Tag, T> {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.0.to_haskell(writer, PhantomData)
+    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        match self.0.to_haskell(writer, PhantomData) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+        }
     }
 }
 
 impl<Tag, T: FromHaskell<Tag>> BorshDeserialize for Haskell<Tag, T> {
     fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
         let tag: PhantomData<Tag> = PhantomData;
-        T::from_haskell(buf, tag).map(tag_val)
+        match T::from_haskell(buf, tag).map(tag_val) {
+            Ok(x) => Ok(x),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+        }
     }
 }

--- a/haskell-ffi/src/error.rs
+++ b/haskell-ffi/src/error.rs
@@ -1,0 +1,2 @@
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Result<T> = core::result::Result<T, Error>;

--- a/haskell-ffi/src/from_haskell.rs
+++ b/haskell-ffi/src/from_haskell.rs
@@ -1,9 +1,6 @@
-use std::{
-    io::{Error, ErrorKind},
-    marker::PhantomData,
-};
+use std::{io::ErrorKind, marker::PhantomData};
 
-use crate::HaskellSize;
+use crate::{error::Error, HaskellSize};
 
 /*******************************************************************************
   Main class definition
@@ -23,7 +20,10 @@ pub trait FromHaskell<Tag>: Sized {
         let mut slice_mut = slice;
         let result = Self::from_haskell(&mut slice_mut, tag)?;
         if !slice_mut.is_empty() {
-            return Err(Error::new(ErrorKind::InvalidData, ERROR_NOT_ALL_BYTES_READ));
+            return Err(Box::new(std::io::Error::new(
+                ErrorKind::InvalidData,
+                ERROR_NOT_ALL_BYTES_READ,
+            )));
         }
         Ok(result)
     }

--- a/haskell-ffi/src/lib.rs
+++ b/haskell-ffi/src/lib.rs
@@ -6,6 +6,7 @@ mod macros;
 
 pub mod bincode;
 pub mod deriving_via;
+pub mod error;
 pub mod from_haskell;
 pub mod haskell_size;
 pub mod to_haskell;

--- a/haskell-ffi/src/to_haskell.rs
+++ b/haskell-ffi/src/to_haskell.rs
@@ -1,10 +1,6 @@
-use std::{
-    fmt::Display,
-    io::{Error, Write},
-    marker::PhantomData,
-};
+use std::{fmt::Display, io::Write, marker::PhantomData};
 
-use crate::HaskellSize;
+use crate::{error::Result, HaskellSize};
 
 /*******************************************************************************
   Main class definition
@@ -23,9 +19,9 @@ pub trait ToHaskell<Tag> {
     /// `solana-sdk-haskell` library can define a `ToHaskell` instance for
     /// `Keypair`, defined in `solana-sdk`, as long as it uses a tag `Solana`
     /// defined locally in the `solana-haskell-sdk` package.
-    fn to_haskell<W: Write>(&self, writer: &mut W, tag: PhantomData<Tag>) -> Result<(), Error>;
+    fn to_haskell<W: Write>(&self, writer: &mut W, tag: PhantomData<Tag>) -> Result<()>;
 
-    fn to_haskell_vec(&self, tag: PhantomData<Tag>) -> Result<Vec<u8>, Error> {
+    fn to_haskell_vec(&self, tag: PhantomData<Tag>) -> Result<Vec<u8>> {
         let mut result = Vec::with_capacity(DEFAULT_SERIALIZER_CAPACITY);
         self.to_haskell(&mut result, tag)?;
         Ok(result)
@@ -33,7 +29,7 @@ pub trait ToHaskell<Tag> {
 }
 
 impl<Tag, T: ToHaskell<Tag>> ToHaskell<Tag> for &T {
-    fn to_haskell<W: Write>(&self, writer: &mut W, tag: PhantomData<Tag>) -> Result<(), Error> {
+    fn to_haskell<W: Write>(&self, writer: &mut W, tag: PhantomData<Tag>) -> Result<()> {
         (*self).to_haskell(writer, tag)
     }
 }
@@ -95,7 +91,7 @@ pub fn marshall_to_haskell_var<Tag, T>(
 
 /// Wrapper around `marshall_to_haskell_var` that calls `format` for errors
 pub fn marshall_result_to_haskell_var<Tag, T, E>(
-    res: &Result<T, E>,
+    res: &core::result::Result<T, E>,
     out: *mut u8,
     out_len: &mut usize,
     tag: PhantomData<Tag>,
@@ -103,7 +99,7 @@ pub fn marshall_result_to_haskell_var<Tag, T, E>(
     T: ToHaskell<Tag>,
     E: Display,
 {
-    let res: Result<&T, String> = match res {
+    let res: core::result::Result<&T, String> = match res {
         Ok(t) => Ok(t),
         Err(e) => Err(format!("{}", e)),
     };


### PR DESCRIPTION
This makes client code a bit easier to write, since we can then use `?;` in more situations to just cast any kind of error.